### PR TITLE
Condition pour empêcher le cnfs de faire mp oublier si il ne s'est pas inscrit !

### DIFF
--- a/src/services/users/users.class.js
+++ b/src/services/users/users.class.js
@@ -493,7 +493,8 @@ exports.Users = class Users extends Service {
       const user = users.data[0];
       let hiddenEmail = '';
       if (user.roles.includes('conseiller') && user.passwordCreated === false) {
-        res.status(409).send(new Conflict('Vous ne vous etes pas encore inscrite', {
+        // eslint-disable-next-line max-len
+        res.status(401).send(new NotAuthenticated('Vous n\'avez pas encore activé votre compte, veuillez l\'activé via le mail avec l\'intitulé "Activer votre compte Coop des Conseillers numériques France Services."', {
           username
         }).toJSON());
         return;

--- a/src/services/users/users.class.js
+++ b/src/services/users/users.class.js
@@ -493,7 +493,7 @@ exports.Users = class Users extends Service {
       let hiddenEmail = '';
       if (user.roles.includes('conseiller') && user.passwordCreated === false) {
         // eslint-disable-next-line max-len
-        res.status(401).send(new NotAuthenticated('Vous n\'avez pas encore activé votre compte, veuillez l\'activé via le mail avec l\'intitulé "Activer votre compte Coop des Conseillers numériques France Services."', {
+        res.status(409).send(new Conflict(`Vous n'avez pas encore activé votre compte, veuillez l'activé via le mail avec l'intitulé "Activer votre compte Coop des Conseillers numériques France Services.`, {
           username
         }).toJSON());
         return;

--- a/src/services/users/users.class.js
+++ b/src/services/users/users.class.js
@@ -493,7 +493,7 @@ exports.Users = class Users extends Service {
       let hiddenEmail = '';
       if (user.roles.includes('conseiller') && user.passwordCreated === false) {
         // eslint-disable-next-line max-len
-        res.status(409).send(new Conflict(`Vous n'avez pas encore activé votre compte, veuillez l'activé via le mail avec l'intitulé "Activer votre compte Coop des Conseillers numériques France Services.`, {
+        res.status(409).send(new Conflict(`Vous n'avez pas encore activé votre compte. Pour cela, cliquez sur le lien d'activation fourni dans le mail ayant pour objet "Activer votre compte Coop des Conseillers numériques France Services"`, {
           username
         }).toJSON());
         return;

--- a/src/services/users/users.class.js
+++ b/src/services/users/users.class.js
@@ -331,7 +331,7 @@ exports.Users = class Users extends Service {
           const emails = createEmails(db, mailer);
           let message = emails.getEmailMessageByTemplateName('invitationCompteStructure');
           await message.send(newUser, email);
-          
+
           let messageCoop = emails.getEmailMessageByTemplateName('invitationStructureEspaceCoop');
           await messageCoop.send(newUser);
 
@@ -492,7 +492,12 @@ exports.Users = class Users extends Service {
       }
       const user = users.data[0];
       let hiddenEmail = '';
-
+      if (user.roles.includes('conseiller') && user.passwordCreated === false) {
+        res.status(409).send(new Conflict('Vous ne vous etes pas encore inscrite', {
+          username
+        }).toJSON());
+        return;
+      }
       //Si le user est un conseiller, on renvoie l'email obscurci
       if (user.roles[0] === 'conseiller') {
         const hide = t => {


### PR DESCRIPTION
Contexte:
j'ai constaté plusieurs cas où les conseillers font mot de passe oublier avant de passer par l'email qu'il ont reçue pour s'inscrire !
du coup en fessant mp oublier, la clé `passwordCreated`  passe à true alors qu'il n'ont pas encore créer leur espace coop + mattermost + email pro !
Du coup la condition consiste à vérifier qu'il s'est bien inscrit pour pouvoir faire MP oublier !
et c'est également à cause du fait que le lien ne marche plus !