### PR TITLE
Fallback si pas de coordonnées pour l'adresse de la structure

### DIFF
--- a/src/services/conseillers/geolocalisation/core/geolocalisation.core.js
+++ b/src/services/conseillers/geolocalisation/core/geolocalisation.core.js
@@ -6,11 +6,17 @@ const formatStructure = structure => ({
   ...structure.insee ? { address: formatAddress(structure.insee.etablissement.adresse) } : {}
 });
 
+const getGeometry = geolocatedConseiller =>
+  geolocatedConseiller.structure.coordonneesInsee ?
+    { ...geolocatedConseiller.structure.coordonneesInsee } :
+    { ...geolocatedConseiller.structure.location };
+
 const toGeoJson = geolocatedConseiller => ({
   type: 'Feature',
-  geometry: { ...geolocatedConseiller.structure.coordonneesInsee },
+  geometry: getGeometry(geolocatedConseiller),
   properties: {
     id: geolocatedConseiller._id,
+    structureId: geolocatedConseiller.structure._id,
     ...formatStructure(geolocatedConseiller.structure)
   }
 });

--- a/src/services/conseillers/geolocalisation/core/geolocalisation.core.spec.js
+++ b/src/services/conseillers/geolocalisation/core/geolocalisation.core.spec.js
@@ -148,4 +148,45 @@ describe('conseillers géolocalisés', () => {
 
     expect(conseillers).toStrictEqual(expectedConseillers);
   });
+
+  it('devrait utiliser les coordonnées gps de la commune lorsque les coordonnées de la structure ne sont pas disponibles', async () => {
+    const expectedConseillers = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [3.158667, 46.987344]
+          },
+          properties: {
+            id: '4c38ebc9a06fdd532bf9d7be',
+            name: 'Association pour la formation au numérique à Bessenay',
+            isLabeledFranceServices: true,
+          }
+        }
+      ]
+    };
+
+    const getConseillerWithGeolocation = async () => [
+      {
+        _id: '4c38ebc9a06fdd532bf9d7be',
+        structure: {
+          nom: 'Association pour la formation au numérique à Bessenay',
+          estLabelliseFranceServices: 'OUI',
+          location: {
+            type: 'Point',
+            coordinates: [
+              3.158667,
+              46.987344
+            ]
+          }
+        }
+      }
+    ];
+
+    const conseillers = await geolocatedConseillers({ getConseillerWithGeolocation });
+
+    expect(conseillers).toStrictEqual(expectedConseillers);
+  });
 });

--- a/src/services/conseillers/geolocalisation/repository/geolocalisation.repository.js
+++ b/src/services/conseillers/geolocalisation/repository/geolocalisation.repository.js
@@ -19,14 +19,10 @@ const getConseillerWithGeolocation = db => async () =>
     },
     { $unwind: '$structure' },
     {
-      $match: {
-        'structure.coordonneesInsee': { $ne: null }
-      }
-    },
-    {
       $project: {
         '_id': 1,
         'structure.coordonneesInsee': 1,
+        'structure.location': 1,
         'structure.nom': 1,
         'structure.estLabelliseFranceServices': 1,
         'structure.insee.etablissement.adresse': 1


### PR DESCRIPTION
Utilisation des coordonnées de la commune dans laquelle se trouve la structure si sa localisation n'est pas définie.