### PR TITLE
refactor: Mise à jour du schéma des lieux de médiation numérique

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@feathersjs/express": "4.5.11",
     "@feathersjs/feathers": "4.5.11",
     "@feathersjs/transport-commons": "4.5.11",
-    "@gouvfr-anct/lieux-de-mediation-numerique": "1.12.1",
+    "@gouvfr-anct/lieux-de-mediation-numerique": "1.12.2",
     "@hapi/boom": "9.1.1",
     "@sentry/node": "6.11.0",
     "@sentry/tracing": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@feathersjs/express": "4.5.11",
     "@feathersjs/feathers": "4.5.11",
     "@feathersjs/transport-commons": "4.5.11",
+    "@gouvfr-anct/lieux-de-mediation-numerique": "1.12.1",
     "@hapi/boom": "9.1.1",
     "@sentry/node": "6.11.0",
     "@sentry/tracing": "6.11.0",

--- a/src/services/permanence-conseillers/permanence/core/aidants-error.js
+++ b/src/services/permanence-conseillers/permanence/core/aidants-error.js
@@ -1,0 +1,9 @@
+class AidantsError extends Error {
+  constructor() {
+    super('Il devrait y avoir au moins un aidant visible dans une permanence');
+  }
+}
+
+module.exports = {
+  AidantsError
+};

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
@@ -1,9 +1,18 @@
+/* eslint-disable new-cap */
+
 const { toOsmOpeningHours, OSM_DAYS_OF_WEEK } = require('../utils/osm-opening-hours/osm-opening-hours');
+const { Pivot, Adresse, Localisation, Contact, ConditionsAcces, Services, LabelsNationaux, Url, Service,
+  LabelNational, ConditionAcces, toSchemaLieuMediationNumerique, Id, Nom, NomError, IdError, CommuneError, CodePostalError, VoieError
+} = require('@gouvfr-anct/lieux-de-mediation-numerique');
+const { AidantsError } = require('./aidants-error');
 
 // eslint-disable-next-line max-len
 const URL_REGEXP = /^(?:https?:\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4])|(?:[a-z\u00a1-\uffff\d]-*)*[a-z\u00a1-\uffff\d]+(?:\.(?:[a-z\u00a1-\uffff\d]-*)*[a-z\u00a1-\uffff\d]+)*\.[a-z\u00a1-\uffff]{2,})(?::\d{2,5})?(?:\/\S*)?$/;
 
 const PHONE_REGEX = /^(?:(?:\+)(33|590|596|594|262|269))(?:\d{3}){3}$/;
+
+// eslint-disable-next-line max-len
+const COURRIEL_REGEXP = /^(?:(?:[^<>()[\]\\.,;:\s@"]+(?:\.[^<>()[\]\\.,;:\s@"]+)*)|(?:".+"))@(?:(?:\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}])|(?:(?:[A-Za-zÀ-ÖØ-öø-ÿ\-\d]+\.)+[a-zA-Z]{2,}))$/;
 
 const removeAllSpaces = string => string?.replaceAll(' ', '') ?? null;
 
@@ -19,67 +28,28 @@ const removeAllSpacesAndDuplicateHttpPrefix = siteWeb => removeAllSpaces(siteWeb
 const addMissingHttpsPrefix = siteWeb =>
   siteWeb && (siteWeb.startsWith('https://') || siteWeb.startsWith('http://')) ? siteWeb : `https://${siteWeb}`;
 
-const removeSuperfluousSpaces = string => string?.trim().replaceAll(/\s+/g, ' ') ?? null;
+const formatUrl = url => addMissingHttpsPrefix(removeAllSpacesAndDuplicateHttpPrefix(url));
 
-const nullOrEmpty = string => string === null || string === '';
+const removeSuperfluousSpaces = string => string?.trim().replaceAll(/\s+/g, ' ') ?? '';
 
-const invalidLieux = lieu =>
-  !nullOrEmpty(lieu.id) &&
-  !nullOrEmpty(lieu.nom) &&
-  !nullOrEmpty(lieu.commune) &&
-  !nullOrEmpty(lieu.code_postal) &&
-  !nullOrEmpty(lieu.adresse) &&
-  lieu.hasOwnProperty('aidants') &&
-  !nullOrEmpty(lieu.structureId);
+const keepDefined = lieu => lieu !== undefined;
 
 const removeNullStrings = string => string
 .replaceAll('null null', '')
 .replaceAll('null ', '');
 
-const pivotIfAny = pivot => pivot ? {
-  pivot: removeAllSpaces(pivot)
-} : {};
-
-const priseRdvIfAny = priseRdv => {
-  const fixedPriseRdv = addMissingHttpsPrefix(removeAllSpacesAndDuplicateHttpPrefix(priseRdv));
-
-  return fixedPriseRdv && URL_REGEXP.test(fixedPriseRdv) ? {
-    prise_rdv: fixedPriseRdv
-  } : {};
-};
-
-const coordonneesGPSIfAny = coordinates => coordinates ? {
-  latitude: coordinates[1],
-  longitude: coordinates[0]
-} : {};
+const priseRdvIfAny = priseRdv => priseRdv && URL_REGEXP.test(priseRdv) ? { prise_rdv: Url(priseRdv) } : {};
 
 const checkLengthPhone = telephone =>
   PHONE_REGEX.test(telephone) || (telephone.startsWith('0') && telephone.length === 10);
 
-const telephoneIfAny = telephone => {
-  const formattedTel = formatPhone(telephone);
+const telephoneIfAny = telephone => telephone && checkLengthPhone(telephone) ? { telephone } : {};
 
-  return formattedTel && checkLengthPhone(formattedTel) ? {
-    telephone: formattedTel
-  } : {};
-};
+const courrielIfAny = courriel => courriel && COURRIEL_REGEXP.test(courriel) ? { courriel } : {};
 
-const courrielIfAny = courriel => courriel ? {
-  courriel: removeAllSpaces(courriel)
-} : {};
+const siteWebIfAny = siteWeb => siteWeb && URL_REGEXP.test(siteWeb) ? { site_web: [siteWeb] } : {};
 
-const siteWebIfAny = siteWeb => {
-  const fixedSiteWeb = addMissingHttpsPrefix(removeAllSpacesAndDuplicateHttpPrefix(siteWeb));
-
-  return fixedSiteWeb && URL_REGEXP.test(fixedSiteWeb) ? {
-    site_web: fixedSiteWeb
-  } : {};
-};
-
-const toTimeTable = horaires => (horaires ?? []).map(horaire => [
-  horaire.matin,
-  horaire.apresMidi
-]
+const toTimeTable = horaires => (horaires ?? []).map(horaire => [horaire.matin, horaire.apresMidi]
 .flat()
 .filter(horaire => horaire !== 'Fermé'))
 .map(horaire =>
@@ -91,30 +61,25 @@ const toTimeTable = horaires => (horaires ?? []).map(horaire => [
   osmHours
 })).filter(openingHour => openingHour.osmHours !== '');
 
-const osmOpeningHoursIfAny = horaires =>
-  horaires.length === 0 ? {} : {
-    horaires: toOsmOpeningHours(horaires)
-  };
-
-const CNFS_COMMON_SERVICES = [
-  'Prendre en main un smartphone ou une tablette',
-  'Prendre en main un ordinateur',
-  'Utiliser le numérique au quotidien',
-  'Approfondir ma culture numérique'
-].join(', ');
-
-const dateMajIfAny = updatedAt => updatedAt ? {
-  date_maj: updatedAt.toISOString().substring(0, 10)
+const horairesIfAny = horaires => horaires ? {
+  horaires: toOsmOpeningHours(toTimeTable(horaires))
 } : {};
 
+const CNFS_COMMON_SERVICES = [
+  Service.PrendreEnMainUnSmartphoneOuUneTablette,
+  Service.PrendreEnMainUnOrdinateur,
+  Service.UtiliserLeNumerique,
+  Service.ApprofondirMaCultureNumerique
+];
 
-const labelsNationauxIfAny = structure => ({
-  labels_nationaux: [
-    'CNFS',
-    ...(structure?.estLabelliseAidantsConnect === 'OUI') ? ['Aidants Connect'] : [],
-    ...(structure?.estLabelliseFranceServices === 'OUI') ? ['France Services'] : []
-  ].join(', ')
-});
+const labelsNationaux = structure =>
+  ({
+    labels_nationaux: LabelsNationaux([
+      LabelNational.CNFS,
+      ...(structure?.estLabelliseAidantsConnect === 'OUI' ? [LabelNational.AidantsConnect] : []),
+      ...(structure?.estLabelliseFranceServices === 'OUI' ? [LabelNational.FranceServices] : [])
+    ])
+  });
 
 const formatNomAidant = (prenom, nom) => ({
   nom: (prenom + ' ' + nom).toLowerCase().replace(/(^\w{1})|([\s,-]+\w{1})/g, letter => letter.toUpperCase())
@@ -129,6 +94,10 @@ const removeDuplicates = array => {
   });
 };
 
+const throwNoAidantsError = () => {
+  throw new AidantsError();
+};
+
 const aidantsIfAny = aidants =>
   // Retire les aidants souhaitant être "anonyme"
   aidants?.filter(aidant => aidant.nonAffichageCarto !== true)?.length > 0 ? {
@@ -137,36 +106,76 @@ const aidantsIfAny = aidants =>
     .map(aidant => ({
       aidantId: aidant._id,
       ...formatNomAidant(aidant.prenom, aidant.nom),
-      ...courrielIfAny(aidant.emailPro),
-      ...telephoneIfAny(aidant.telephonePro)
+      ...courrielIfAny(removeAllSpaces(aidant.emailPro)),
+      ...telephoneIfAny(formatPhone(aidant.telephonePro))
     }))
     // eslint-disable-next-line no-nested-ternary
     .sort((aidant1, aidant2) => (aidant1.nom > aidant2.nom) ? 1 : ((aidant2.nom > aidant1.nom) ? -1 : 0))
+  } : throwNoAidantsError();
+
+const localistaionIfAny = coordinates =>
+  coordinates !== undefined ? {
+    localisation: Localisation({
+      latitude: coordinates[1],
+      longitude: coordinates[0]
+    })
   } : {};
 
+const REQUIRED_FIELDS_ERRORS = [
+  NomError,
+  IdError,
+  CommuneError,
+  CodePostalError,
+  VoieError,
+  AidantsError
+];
+
+const noInvalidSiret = siret =>
+  siret === '' ||
+  siret === null ||
+  siret.length !== 14 ?
+    '00000000000000' :
+    siret;
+
 const lieuxDeMediationNumerique = async ({ getPermanences }) =>
-  (await getPermanences()).map(permanence => ({
-    id: permanence._id,
-    nom: removeSuperfluousSpaces(permanence.nomEnseigne),
-    commune: removeSuperfluousSpaces(permanence.adresse?.ville),
-    code_postal: removeAllSpaces(permanence.adresse?.codePostal),
-    adresse: removeSuperfluousSpaces(removeNullStrings([permanence.adresse.numeroRue, permanence.adresse.rue].join(' '))),
-    ...coordonneesGPSIfAny(permanence.location?.coordinates),
-    ...telephoneIfAny(permanence.numeroTelephone),
-    ...courrielIfAny(permanence.email),
-    ...siteWebIfAny(permanence.siteWeb),
-    ...osmOpeningHoursIfAny(toTimeTable(permanence.horaires)),
-    source: 'conseiller-numerique',
-    ...dateMajIfAny(permanence.updatedAt),
-    services: CNFS_COMMON_SERVICES,
-    conditions_access: 'Gratuit',
-    ...labelsNationauxIfAny(permanence.structure),
-    ...priseRdvIfAny(permanence.structure?.urlPriseRdv),
-    ...pivotIfAny(permanence.siret),
-    structureId: permanence.structure?._id,
-    structureNom: permanence.structure?.nom,
-    ...aidantsIfAny(permanence.aidants),
-  })).filter(invalidLieux);
+  (await getPermanences()).map(permanence => {
+    try {
+      return {
+        ...toSchemaLieuMediationNumerique({
+          id: Id(permanence._id),
+          pivot: Pivot(noInvalidSiret(removeAllSpaces(permanence.siret))),
+          nom: Nom(removeSuperfluousSpaces(permanence.nomEnseigne)),
+          adresse: Adresse({
+            voie: removeSuperfluousSpaces(removeNullStrings([permanence.adresse.numeroRue, permanence.adresse.rue].join(' '))),
+            code_postal: removeAllSpaces(permanence.adresse?.codePostal),
+            commune: removeSuperfluousSpaces(permanence.adresse?.ville),
+          }),
+          ...localistaionIfAny(permanence.location?.coordinates),
+          contact: Contact({
+            ...telephoneIfAny(formatPhone(permanence.numeroTelephone)),
+            ...courrielIfAny(removeAllSpaces(permanence.email)),
+            ...siteWebIfAny(formatUrl(permanence.siteWeb))
+          }),
+          ...horairesIfAny(permanence.horaires),
+          source: 'conseiller-numerique',
+          date_maj: permanence.updatedAt,
+          services: Services(CNFS_COMMON_SERVICES),
+          conditions_acces: ConditionsAcces([ConditionAcces.Gratuit]),
+          ...labelsNationaux(permanence.structure),
+          ...priseRdvIfAny(formatUrl(permanence.structure?.urlPriseRdv))
+        }),
+        structureId: permanence.structure?._id,
+        structureNom: permanence.structure?.nom,
+        ...aidantsIfAny(permanence.aidants),
+      };
+    } catch (error) {
+      if (REQUIRED_FIELDS_ERRORS.some(requiredFieldError => error instanceof requiredFieldError)) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }).filter(keepDefined);
 
 module.exports = {
   lieuxDeMediationNumerique,

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
@@ -100,7 +100,7 @@ const aidantsIfAny = aidants =>
   // Retire les aidants souhaitant être "anonyme"
   aidants?.filter(aidant => aidant.nonAffichageCarto !== true)?.length > 0 ? {
     aidants:
-    removeDuplicates(aidants)
+    removeDuplicates(aidants.filter(aidant => aidant.nonAffichageCarto !== true))
     .map(aidant => ({
       aidantId: aidant._id,
       ...formatNomAidant(aidant.prenom, aidant.nom),

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
@@ -113,7 +113,7 @@ const aidantsIfAny = aidants =>
     .sort((aidant1, aidant2) => (aidant1.nom > aidant2.nom) ? 1 : ((aidant2.nom > aidant1.nom) ? -1 : 0))
   } : throwNoAidantsError();
 
-const localistaionIfAny = coordinates =>
+const localisationIfAny = coordinates =>
   coordinates !== undefined ? {
     localisation: Localisation({
       latitude: coordinates[1],
@@ -150,7 +150,7 @@ const lieuxDeMediationNumerique = async ({ getPermanences }) =>
             code_postal: removeAllSpaces(permanence.adresse?.codePostal),
             commune: removeSuperfluousSpaces(permanence.adresse?.ville),
           }),
-          ...localistaionIfAny(permanence.location?.coordinates),
+          ...localisationIfAny(permanence.location?.coordinates),
           contact: Contact({
             ...telephoneIfAny(formatPhone(permanence.numeroTelephone)),
             ...courrielIfAny(removeAllSpaces(permanence.email)),

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
@@ -61,9 +61,7 @@ const toTimeTable = horaires => (horaires ?? []).map(horaire => [horaire.matin, 
   osmHours
 })).filter(openingHour => openingHour.osmHours !== '');
 
-const horairesIfAny = horaires => horaires && horaires !== '' ? {
-  horaires: toOsmOpeningHours(toTimeTable(horaires))
-} : {};
+const horairesIfAny = horaires => horaires ? { horaires } : {};
 
 const CNFS_COMMON_SERVICES = [
   Service.PrendreEnMainUnSmartphoneOuUneTablette,
@@ -165,7 +163,7 @@ const lieuxDeMediationNumerique = async ({ getPermanences }) =>
             ...courrielIfAny(removeAllSpaces(permanence.email)),
             ...siteWebIfAny(formatUrl(permanence.siteWeb))
           }),
-          ...horairesIfAny(permanence.horaires),
+          ...horairesIfAny(toOsmOpeningHours(toTimeTable(permanence.horaires))),
           source: 'conseiller-numerique',
           date_maj: permanence.updatedAt,
           services: Services(CNFS_COMMON_SERVICES),

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.js
@@ -61,7 +61,7 @@ const toTimeTable = horaires => (horaires ?? []).map(horaire => [horaire.matin, 
   osmHours
 })).filter(openingHour => openingHour.osmHours !== '');
 
-const horairesIfAny = horaires => horaires ? {
+const horairesIfAny = horaires => horaires && horaires !== '' ? {
   horaires: toOsmOpeningHours(toTimeTable(horaires))
 } : {};
 
@@ -137,6 +137,15 @@ const noInvalidSiret = siret =>
     '00000000000000' :
     siret;
 
+const formatCodePostal = codePostal => removeAllSpaces(codePostal)?.slice(0, 5);
+
+const formatCommune = ville => removeSuperfluousSpaces(
+  ville
+  ?.replace('.', '')
+  .replace(/\(.*\)/gu, '')
+  .replace(/.*,/gu, '')
+);
+
 const lieuxDeMediationNumerique = async ({ getPermanences }) =>
   (await getPermanences()).map(permanence => {
     try {
@@ -147,8 +156,8 @@ const lieuxDeMediationNumerique = async ({ getPermanences }) =>
           nom: Nom(removeSuperfluousSpaces(permanence.nomEnseigne)),
           adresse: Adresse({
             voie: removeSuperfluousSpaces(removeNullStrings([permanence.adresse.numeroRue, permanence.adresse.rue].join(' '))),
-            code_postal: removeAllSpaces(permanence.adresse?.codePostal),
-            commune: removeSuperfluousSpaces(permanence.adresse?.ville),
+            code_postal: formatCodePostal(permanence.adresse?.codePostal),
+            commune: formatCommune(permanence.adresse?.ville),
           }),
           ...localisationIfAny(permanence.location?.coordinates),
           contact: Contact({

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
@@ -1,4 +1,8 @@
-const { lieuxDeMediationNumerique, CNFS_COMMON_SERVICES } = require('./lieux-de-mediation-numerique.core');
+const { lieuxDeMediationNumerique } = require('./lieux-de-mediation-numerique.core');
+const { ConditionAcces, Service, LabelNational } = require('@gouvfr-anct/lieux-de-mediation-numerique');
+
+// eslint-disable-next-line max-len
+const TEST_SERVICES = `${Service.PrendreEnMainUnSmartphoneOuUneTablette};${Service.PrendreEnMainUnOrdinateur};${Service.UtiliserLeNumerique};${Service.ApprofondirMaCultureNumerique}`;
 
 describe('lieux de médiation numérique', () => {
   it('devrait avoir les informations obligatoires du schéma de médiation numérique avec extension CnFS', async () => {
@@ -11,6 +15,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -26,12 +31,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        // eslint-disable-next-line max-len
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -53,6 +61,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -72,9 +81,10 @@ describe('lieux de médiation numérique', () => {
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -96,6 +106,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -115,9 +126,100 @@ describe('lieux de médiation numérique', () => {
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+  it('devrait avoir un siret avec la valeur 00000000000000 quand celui ci est initialement null', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      siret: null,
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Reims',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        pivot: '00000000000000',
+        nom: 'Anonymal',
+        commune: 'Reims',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+  it('devrait avoir un siret avec la valeur 00000000000000 quand celui ci est initialement vide', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      siret: '',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Reims',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        pivot: '00000000000000',
+        nom: 'Anonymal',
+        commune: 'Reims',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -138,6 +240,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -153,12 +256,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -179,6 +284,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -194,12 +300,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Association Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -220,6 +328,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -244,6 +353,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -260,7 +370,6 @@ describe('lieux de médiation numérique', () => {
 
   it('devrait exclure les lieux dont l\'id structure n\'est pas renseignée', async () => {
     const permanence = {
-      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
       nomEnseigne: '',
       adresse: {
         ville: 'Reims',
@@ -268,6 +377,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       aidants: [
         { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
       ]
@@ -283,11 +393,11 @@ describe('lieux de médiation numérique', () => {
       _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
       nomEnseigne: 'Anonymal',
       adresse: {
-        ville: 'Reims',
         codePostal: '51100',
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -299,24 +409,7 @@ describe('lieux de médiation numérique', () => {
 
     const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
 
-    expect(lieux).toStrictEqual([
-      {
-        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
-        nom: 'Anonymal',
-        commune: 'Reims',
-        code_postal: '51100',
-        adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
-        source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS',
-        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
-        structureNom: 'Gare CnFS',
-        aidants: [
-          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
-        ]
-      }
-    ]);
+    expect(lieux).toStrictEqual([]);
   });
 
   it('devrait avoir une commune sans espaces superflus', async () => {
@@ -329,6 +422,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -344,12 +438,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Villeneuve sur Eure',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -366,92 +462,10 @@ describe('lieux de médiation numérique', () => {
       nomEnseigne: 'Anonymal',
       adresse: {
         ville: 'Reims',
-        codePostal: '51100',
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
-      structure: {
-        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
-        nom: 'Gare CnFS'
-      },
-      aidants: [
-        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
-      ]
-    };
-
-    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
-
-    expect(lieux).toStrictEqual([
-      {
-        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
-        nom: 'Anonymal',
-        commune: 'Reims',
-        code_postal: '51100',
-        adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
-        source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS',
-        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
-        structureNom: 'Gare CnFS',
-        aidants: [
-          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
-        ]
-      }
-    ]);
-  });
-
-  it('devrait avoir un code postal sans espaces', async () => {
-    const permanence = {
-      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
-      nomEnseigne: 'Anonymal',
-      adresse: {
-        ville: 'Reims',
-        codePostal: '51 100',
-        numeroRue: '12 BIS',
-        rue: 'RUE DE LECLERCQ'
-      },
-      structure: {
-        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
-        nom: 'Gare CnFS'
-      },
-      aidants: [
-        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
-      ]
-    };
-
-    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
-
-    expect(lieux).toStrictEqual([
-      {
-        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
-        nom: 'Anonymal',
-        commune: 'Reims',
-        code_postal: '51100',
-        adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
-        source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS',
-        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
-        structureNom: 'Gare CnFS',
-        aidants: [
-          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
-        ]
-      }
-    ]);
-  });
-
-  it('devrait filtrer les codes postaux nuls', async () => {
-    const permanence = {
-      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
-      nomEnseigne: 'Anonymal',
-      adresse: {
-        ville: 'Reims',
-        codePostal: null,
-        numeroRue: '12 BIS',
-        rue: 'RUE DE LECLERCQ'
-      },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -466,7 +480,76 @@ describe('lieux de médiation numérique', () => {
     expect(lieux).toStrictEqual([]);
   });
 
-  it('devrait filtrer les codes postaux vides', async () => {
+  it('devrait avoir un code postal sans espaces', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Reims',
+        codePostal: '51 100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'Reims',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+  it('devrait exclure les lieux dont les codes postaux nuls', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Reims',
+        codePostal: null,
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([]);
+  });
+
+  it('devrait exclure les lieux dont les codes postaux vides', async () => {
     const permanence = {
       _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
       nomEnseigne: 'Anonymal',
@@ -476,6 +559,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -500,6 +584,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -515,12 +600,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -541,6 +628,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -556,12 +644,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -582,6 +672,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: ' 12  BIS ',
         rue: '  RUE DE  LECLERCQ '
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -597,12 +688,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -623,6 +716,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: ' 12 null',
         rue: '  RUE DE LECLERCQ '
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -638,12 +732,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -664,6 +760,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: 'null',
         rue: 'null'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -688,6 +785,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: null,
         rue: null
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -718,6 +816,7 @@ describe('lieux de médiation numérique', () => {
           43.52609
         ]
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -733,14 +832,16 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         latitude: 43.52609,
         longitude: 5.41423,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -762,6 +863,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: '+33180059880',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -777,13 +879,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         telephone: '+33180059880',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -805,6 +909,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: ' +33 1 80 05 98 80 ',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -820,13 +925,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         telephone: '+33180059880',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -848,6 +955,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: '+33.1.80.05.98.80',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -863,13 +971,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         telephone: '+33180059880',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -891,6 +1001,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: '+330562636539',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -906,13 +1017,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         telephone: '+33562636539',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -934,6 +1047,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: '+33123456',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -949,12 +1063,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -976,6 +1092,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       numeroTelephone: '0111',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -991,12 +1108,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1018,6 +1137,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       email: 'contact@laquincaillerie.tl',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1033,13 +1153,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         courriel: 'contact@laquincaillerie.tl',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1061,6 +1183,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       email: ' contact@laquincaillerie.tl   ',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1076,13 +1199,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         courriel: 'contact@laquincaillerie.tl',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1104,6 +1229,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       siteWeb: 'https://www.laquincaillerie.tl/',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1119,13 +1245,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         site_web: 'https://www.laquincaillerie.tl/',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1147,6 +1275,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       siteWeb: 'www.laquincaillerie.tl/',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1162,13 +1291,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         site_web: 'https://www.laquincaillerie.tl/',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1190,6 +1321,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       siteWeb: '  https://  www.laquincaillerie.tl/  ',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1205,13 +1337,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         site_web: 'https://www.laquincaillerie.tl/',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1233,6 +1367,7 @@ describe('lieux de médiation numérique', () => {
         rue: 'RUE DE LECLERCQ'
       },
       siteWeb: 'https://www.https://www.laquincaillerie.tl/',
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1248,13 +1383,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         site_web: 'https://www.laquincaillerie.tl/',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1347,6 +1484,7 @@ describe('lieux de médiation numérique', () => {
           ]
         }
       ],
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1362,13 +1500,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         horaires: 'Mo 09:30-10:45; Tu 11:15-12:45; We 13:30-14:25; Th 8:00-9:25,15:00-16:05; Fr 16:20-17:15; Sa 18:30-19:00; Su 19:50-23:55',
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1405,12 +1545,13 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        conditions_acces: ConditionAcces.Gratuit,
         date_maj: '2022-06-02',
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
@@ -1432,6 +1573,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1448,13 +1590,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS, France Services',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: `${LabelNational.CNFS};${LabelNational.FranceServices}`,
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
         aidants: [
@@ -1474,6 +1618,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1490,13 +1635,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS, Aidants Connect',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: `${LabelNational.CNFS};${LabelNational.AidantsConnect}`,
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
         aidants: [
@@ -1516,6 +1663,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1533,13 +1681,15 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
-        labels_nationaux: 'CNFS, Aidants Connect, France Services',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: `${LabelNational.CNFS};${LabelNational.AidantsConnect};${LabelNational.FranceServices}`,
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
         aidants: [
@@ -1559,6 +1709,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1575,12 +1726,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         prise_rdv: 'https://www.url-rdv.fr/org/1234',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
@@ -1602,6 +1755,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1618,12 +1772,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         prise_rdv: 'https://www.url-rdv.fr/org/1234',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
@@ -1645,6 +1801,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1661,12 +1818,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         prise_rdv: 'https://www.url-rdv.fr/org/1234',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
@@ -1688,6 +1847,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS',
@@ -1704,12 +1864,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         prise_rdv: 'https://www.url-rdv.fr/org/1234',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
@@ -1731,6 +1893,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1753,6 +1916,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1777,6 +1941,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1792,12 +1957,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1818,6 +1985,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1834,12 +2002,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1860,6 +2030,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1878,12 +2049,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1906,6 +2079,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1923,12 +2097,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',
@@ -1951,6 +2127,7 @@ describe('lieux de médiation numérique', () => {
         numeroRue: '12 BIS',
         rue: 'RUE DE LECLERCQ'
       },
+      updatedAt: new Date('2022-12-01'),
       structure: {
         _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         nom: 'Gare CnFS'
@@ -1969,12 +2146,14 @@ describe('lieux de médiation numérique', () => {
       {
         id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
         nom: 'Anonymal',
+        pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
         adresse: '12 BIS RUE DE LECLERCQ',
-        services: CNFS_COMMON_SERVICES,
+        services: TEST_SERVICES,
         source: 'conseiller-numerique',
-        conditions_access: 'Gratuit',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
         labels_nationaux: 'CNFS',
         structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
         structureNom: 'Gare CnFS',

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
@@ -2152,6 +2152,51 @@ describe('lieux de médiation numérique', () => {
     ]);
   });
 
+  it('devrait ne remonter que les aidants non anonymes', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Reims',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' },
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3ggg', prenom: 'Jean', nom: 'Anonyme', emailPro: 'jean.anonyme@gouv.fr', nonAffichageCarto: true }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'Reims',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
   it('devrait avoir aucun doublon d\'aidant de même id', async () => {
     const permanence = {
       _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',

--- a/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
+++ b/src/services/permanence-conseillers/permanence/core/lieux-de-mediation-numerique.core.spec.js
@@ -456,6 +456,139 @@ describe('lieux de médiation numérique', () => {
     ]);
   });
 
+  it('devrait avoir une commune sans points', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Avallon.',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'Avallon',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+  it('devrait avoir une commune sans points', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Avallon.',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'Avallon',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+
+  it('devrait avoir une commune sans détails placés devant une virgule', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'TAN ROUGE, SAINT PAUL',
+        codePostal: '51100',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'SAINT PAUL',
+        code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
   it('devrait avoir un code postal', async () => {
     const permanence = {
       _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
@@ -509,6 +642,50 @@ describe('lieux de médiation numérique', () => {
         pivot: '00000000000000',
         commune: 'Reims',
         code_postal: '51100',
+        adresse: '12 BIS RUE DE LECLERCQ',
+        services: TEST_SERVICES,
+        source: 'conseiller-numerique',
+        date_maj: '2022-12-01',
+        conditions_acces: ConditionAcces.Gratuit,
+        labels_nationaux: 'CNFS',
+        structureId: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        structureNom: 'Gare CnFS',
+        aidants: [
+          { aidantId: 'aaa88891b3f44bdf86bb7bc2601d3fff', nom: 'Jean Dupond', courriel: 'jean.dupond@gouv.fr', telephone: '+33112341234' }
+        ]
+      }
+    ]);
+  });
+
+  it('devrait avoir un code postal avec le bon nombre de caractères', async () => {
+    const permanence = {
+      _id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+      nomEnseigne: 'Anonymal',
+      adresse: {
+        ville: 'Grenoble',
+        codePostal: '380000',
+        numeroRue: '12 BIS',
+        rue: 'RUE DE LECLERCQ'
+      },
+      updatedAt: new Date('2022-12-01'),
+      structure: {
+        _id: 'abc88891b3f44bdf86bb7bc2601d3ddd',
+        nom: 'Gare CnFS'
+      },
+      aidants: [
+        { _id: 'aaa88891b3f44bdf86bb7bc2601d3fff', prenom: 'Jean', nom: 'Dupond', emailPro: 'jean.dupond@gouv.fr', telephonePro: '+33112341234' }
+      ]
+    };
+
+    const lieux = await lieuxDeMediationNumerique({ getPermanences: () => [permanence] });
+
+    expect(lieux).toStrictEqual([
+      {
+        id: 'abf48891b3f44bdf86bb7bc2601d3d5b',
+        nom: 'Anonymal',
+        pivot: '00000000000000',
+        commune: 'Grenoble',
+        code_postal: '38000',
         adresse: '12 BIS RUE DE LECLERCQ',
         services: TEST_SERVICES,
         source: 'conseiller-numerique',

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,11 @@
     lodash "^4.17.21"
     radix-router "^3.0.1"
 
+"@gouvfr-anct/lieux-de-mediation-numerique@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@gouvfr-anct/lieux-de-mediation-numerique/-/lieux-de-mediation-numerique-1.12.1.tgz#cc98c5a913de119a71f03d8668d3901518f0e635"
+  integrity sha512-MugAPcOl+HrIadaMLxs9cjTk/g6gFQwj62cqrALSRjEYalnffY7fX3Ba9a1wAquHdl/7baSmEJcHDjuNpo27Fw==
+
 "@hapi/boom@9.1.1":
   version "9.1.1"
   resolved "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
     lodash "^4.17.21"
     radix-router "^3.0.1"
 
-"@gouvfr-anct/lieux-de-mediation-numerique@1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@gouvfr-anct/lieux-de-mediation-numerique/-/lieux-de-mediation-numerique-1.12.1.tgz#cc98c5a913de119a71f03d8668d3901518f0e635"
-  integrity sha512-MugAPcOl+HrIadaMLxs9cjTk/g6gFQwj62cqrALSRjEYalnffY7fX3Ba9a1wAquHdl/7baSmEJcHDjuNpo27Fw==
+"@gouvfr-anct/lieux-de-mediation-numerique@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@gouvfr-anct/lieux-de-mediation-numerique/-/lieux-de-mediation-numerique-1.12.2.tgz#767a86f4f8cea090aa26eb859559b0af7a8f0908"
+  integrity sha512-q5Tyiws3T4JDVSmvnE5xfzh0Z5g3081LMgyNVslLeWjKDArRCtIbyg+X+lL3BOXvif4ZWGZblOjSl1tZ9COHqg==
 
 "@hapi/boom@9.1.1":
   version "9.1.1"


### PR DESCRIPTION
:warning: ATTENTION : À publier en même temps que la nouvelle version de la cartographie :warning: 

L'API CnFS et la cartographie ont été les premiers services à se saisir du schéma des lieux de médiation numérique et on fait office de "beta test", entre temps quelques correctifs ont été apportés sur le schéma.

Ces modifications appliquent les correctifs du schéma à l'API CnFS et le même travail a été fait côté carto, pour que tout soit bien compatible et conforme à la version actuelle et en production du schéma de donnée des lieux de médiation numérique.

Pour éviter toute désynchronisation entre le front et le back, il faudra bien veiller à publier en même temps ces modifications apportées à l'API CnFS avec la mise à jour de la cartographie en version 5.0

---

La bibliothèque [@gouvfr-anct/lieux-de-mediation-numerique](https://github.com/anct-cartographie-nationale/lieux-de-mediation-numerique) a été ajoutée. Son rôle est de fournir des fonctions qui permettent de s'assurer que le schéma est respecté, elle est également utilisée dans le front de la carto et dans nos scripts de transformation de données.
Cela évite donc de dupliquer du code de validation et assure que tout fonctionne de la même façon.