### PR TITLE
Erreur de validation explicite sur la route qui met à jour les informations conseiller

### DIFF
--- a/src/services/conseillers/conseillers.class.js
+++ b/src/services/conseillers/conseillers.class.js
@@ -859,7 +859,7 @@ exports.Conseillers = class Conseillers extends Service {
         }
 
         if (extended.error) {
-          res.status(400).json(new BadRequest(schema.error));
+          res.status(400).json(new BadRequest(extended.error));
           return;
         }
 


### PR DESCRIPTION
Pour éviter d'avoir le message `Bad request` en front lorsque l'on modifie ses informations personnelles sur le portail conseiller, on affiche un message explicite.